### PR TITLE
Use the original validator service

### DIFF
--- a/html5check.py
+++ b/html5check.py
@@ -67,7 +67,7 @@ encoding = None
 fileName = None
 contentType = None
 inputHandle = None
-service = 'https://validator.mozillalabs.com/'
+service = 'http://html5.validator.nu/'
 
 for arg in argv:
   if '--help' == arg:


### PR DESCRIPTION
Following 1d5c7153c02897b14feef60bef01a97193c3e3ff, Python script also use the original validator service
instead of Mozilla Labs.
