### PR TITLE
Use SSL for validator requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Options
 * -g : GNU output
 * -e : errors only (no info or warnings)
 * --encoding=foo : declare encoding foo
-* --service=url  : the address of the HTML5 validator (defautls to https://validator.mozillalabs.com/)
+* --service=url  : the address of the HTML5 validator (defaults to https://html5.validator.nu/)
 
 TODO
 --------

--- a/html5-lint.js
+++ b/html5-lint.js
@@ -32,7 +32,7 @@ const outputFormats = [
 const defaults = {
   errorsOnly: false, // level parameter
   output: "json", // out parameter
-  service: "http://html5.validator.nu/",
+  service: "https://html5.validator.nu/",
   showSource: false // showsource parameter
 };
 

--- a/html5check.py
+++ b/html5check.py
@@ -69,7 +69,7 @@ encoding = None
 fileName = None
 contentType = None
 inputHandle = None
-service = 'http://html5.validator.nu/'
+service = 'https://html5.validator.nu/'
 
 argv = sys.argv[1:]
 


### PR DESCRIPTION
* Switch to https protocol for requests to validation service
* Update README to link to correct validation service

Closes #10

Obsoletes #12