### PR TITLE
Use latest version of `extend` depenedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "extend": "~1.1.3",
-    "request": "~2.12.0"
+    "extend": "^2.0.0",
+    "request": "^2.12.0"
   }
 }


### PR DESCRIPTION
When installing `extend@1.1.3` npm emits a mildly annoying deprecation warning.  This will squelch that warning.

Also switched from tilde to caret for semver range, as that is now the default operator that npm uses.