### PR TITLE
Fix parsing response when -g is given

### DIFF
--- a/html5check.py
+++ b/html5check.py
@@ -229,9 +229,10 @@ if response.getheader('Content-Encoding', 'identity').lower() == 'gzip':
   
 if fileName and gnu:
   quotedName = '"%s"' % fileName.replace("'", '\\042')
-  for line in response:
-    sys.stdout.write(quotedName)
-    sys.stdout.write(line)
+  for line in response.read().split('\n'):
+    if line:
+      sys.stdout.write(quotedName)
+      sys.stdout.write(line + '\n')
 else:
   output = response.read()
   # python2/3 difference in output's type


### PR DESCRIPTION
The output from validator.nu has changed causing
htm5check with the `-g` option to fail. Fixes #15.