### PR TITLE
Fix html5-lint.js and html5check.py

### DIFF
--- a/html5-lint.js
+++ b/html5-lint.js
@@ -59,7 +59,8 @@ var Lint = function Lint(input, options, callback) {
   var reqOptions = {
     body: input,
     headers: {
-      'Content-Type': 'text/html; charset=utf-8'
+      'Content-Type': 'text/html; charset=utf-8',
+      'User-Agent': 'html5-lint'
     },
     method: "post",
     uri: options.service,

--- a/html5check.py
+++ b/html5check.py
@@ -206,6 +206,7 @@ while status in (302,301,307) and redirectCount < 10:
     'Content-Type': contentType,
     'Content-Encoding': 'gzip',
     'Content-Length': len(gzippeddata),
+    'User-Agent': 'html5check',
   }
   urlSuffix = '%s?%s' % (parsed[2], parsed[3])
   

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "extend": "^2.0.0",
-    "request": "^2.12.0"
+    "extend": "^3.0.0",
+    "request": "^2.74.0"
   }
 }


### PR DESCRIPTION
Both html5-lint.js and html5check.py stopped working somewhere between August 24th and 25th. The problem seems to be that html5.validator.nu is now requiring User-Agent header to be present, I assume the validator was updated during that time. These commits adds a User-Agent header and fixes the issue. Another commit that upgrades some dependencies is included as well.
