### PR TITLE
fix sys.stdin in python script

### DIFF
--- a/html5check.py
+++ b/html5check.py
@@ -150,18 +150,18 @@ if encoding:
 # Read the file argument (or STDIN)
 #
 if fileName:
-  inputHandle = fileName
-else:
-  inputHandle = sys.stdin
+  with open(fileName, mode='rb') as f:
+    data = f.read()
 
-with open(inputHandle, mode='rb') as inFile:
-  data = inFile.read()
-  with BytesIO() as buf:
-    # we could use another with block here, but it requires Python 2.7+
-    zipFile = gzip.GzipFile(fileobj=buf, mode='wb')
-    zipFile.write(data)
-    zipFile.close()
-    gzippeddata = buf.getvalue()
+else:
+  data = sys.stdin.read()
+
+with BytesIO() as buf:
+  # we could use another with block here, but it requires Python 2.7+
+  zipFile = gzip.GzipFile(fileobj=buf, mode='wb')
+  zipFile.write(data)
+  zipFile.close()
+  gzippeddata = buf.getvalue()
 
 #
 # Prepare the request


### PR DESCRIPTION
This fixes a bug in the Python script where `sys.stdin` was passed to `open()`, which expects a file name.