### PR TITLE
Use /usr/bin/env for script use in VM

### DIFF
--- a/html5check.py
+++ b/html5check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2007-2008 Mozilla Foundation
 #


### PR DESCRIPTION
This changes the python script shebang to use `/usr/bin/env python` instead of `/usr/bin/python` that doesn't exist in some environments (for example docker `node:17-bullseye`).
It will also choose the right interpreter if the script is called inside a venv.